### PR TITLE
1.0.0 readiness

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ matrix:
     - php: 7
     - php: hhvm 
   allow_failures:
-    - php: 7
     - php: hhvm
 
 before_install:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
-## 0.3.1 - TBD
+## 1.0.0 - 2015-12-07
+
+First stable release.
 
 ### Added
 

--- a/composer.json
+++ b/composer.json
@@ -13,11 +13,12 @@
     ],
     "extra": {
         "branch-alias": {
-            "dev-master": "1.0-dev"
+            "dev-master": "1.0-dev",
+            "dev-develop": "1.1-dev"
         }
     },
     "require": {
-        "php": ">=5.5",
+        "php": "^5.5 || ^7.0",
         "psr/http-message": "^1.0",
         "zendframework/zend-expressive-router": "^1.0",
         "zendframework/zend-mvc": "^2.5",


### PR DESCRIPTION
- Updated composer.json:
  - Set PHP dep to `^5.5 || ^7.0`
  - Added develop branch alias
- Updated CHANGELOG
- Updated travis.yml: PHP 7 is no longer allowed to fail
