### PR TITLE
add more "/" in route get 405 Method Not Allowed error

### DIFF
--- a/src/ZendRouter.php
+++ b/src/ZendRouter.php
@@ -88,7 +88,8 @@ class ZendRouter implements RouterInterface
         // Must inject routes prior to matching.
         $this->injectRoutes();
 
-        $match = $this->zendRouter->match(Psr7ServerRequest::toZend($request, true));
+        $zendRequest = Psr7ServerRequest::toZend($request, true);
+        $match = $this->zendRouter->match($zendRequest);
 
         if (null === $match) {
             return RouteResult::fromRouteFailure();
@@ -189,7 +190,7 @@ class ZendRouter implements RouterInterface
             'type'     => 'regex',
             'priority' => -1,
             'options'  => [
-                'regex'    => '/*$',
+                'regex'    => '',
                 'defaults' => [
                     self::METHOD_NOT_ALLOWED_ROUTE => $path,
                 ],

--- a/test/ZendRouterTest.php
+++ b/test/ZendRouterTest.php
@@ -90,7 +90,7 @@ class ZendRouterTest extends TestCase
                     'type'     => 'regex',
                     'priority' => -1,
                     'options'  => [
-                        'regex' => '/*$',
+                        'regex' => '',
                         'defaults' => [
                             ZendRouter::METHOD_NOT_ALLOWED_ROUTE => '/foo',
                         ],
@@ -136,7 +136,7 @@ class ZendRouterTest extends TestCase
                     'type'     => 'regex',
                     'priority' => -1,
                     'options'  => [
-                        'regex' => '/*$',
+                        'regex' => '',
                         'defaults' => [
                             ZendRouter::METHOD_NOT_ALLOWED_ROUTE => '/foo',
                         ],
@@ -198,7 +198,7 @@ class ZendRouterTest extends TestCase
                     'type'     => 'regex',
                     'priority' => -1,
                     'options'  => [
-                        'regex' => '/*$',
+                        'regex' => '',
                         'defaults' => [
                             ZendRouter::METHOD_NOT_ALLOWED_ROUTE => '/foo/:id',
                         ],
@@ -350,5 +350,20 @@ class ZendRouterTest extends TestCase
         $this->assertEquals('/foo', $router->generateUri('foo-list'));
         $this->assertEquals('/foo/bar', $router->generateUri('foo', ['id' => 'bar']));
         $this->assertEquals('/bar/BAZ', $router->generateUri('bar', ['baz' => 'BAZ']));
+    }
+
+    /**
+     * @group 3
+     */
+    public function testPassingTrailingSlashToRouteNotExpectingItResultsIn404FailureRouteResult()
+    {
+        $router = new ZendRouter();
+        $route  = new Route('/api/ping', 'ping', ['GET'], 'ping');
+
+        $router->addRoute($route);
+        $request = new ServerRequest([ 'REQUEST_METHOD' => 'GET' ], [], '/api/ping/', 'GET');
+        $result = $router->match($request);
+        $this->assertTrue($result->isFailure());
+        $this->assertFalse($result->isMethodFailure());
     }
 }


### PR DESCRIPTION
I tried to use zend-expressive-skeleton, apply url /api/ping/ ( more "/" in url ) and got get 405 Method Not Allowed error. 

This is an issue that was reported in https://github.com/zendframework/zend-expressive/issues/257 
