### PR TITLE
Switch to zend-router package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "php": "^5.5 || ^7.0",
         "psr/http-message": "^1.0",
         "zendframework/zend-expressive-router": "^1.0",
-        "zendframework/zend-mvc": "^2.5",
+        "zendframework/zend-router": "^2.5",
         "zendframework/zend-psr7bridge": "^0.2.0"
     },
     "require-dev": {


### PR DESCRIPTION
This updates the component to use the [zend-router](https://github.com/zendframework/zend-router) package instead of zend-mvc, as it only relies on the zend-router functionality.
