### PR TITLE
Populate RouteResult with a Route, and honor HEAD and OPTIONS requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ matrix:
     - php: 7
       env:
         - CS_CHECK=true
+    - php: 7.1
     - php: hhvm 
   allow_failures:
     - php: hhvm
@@ -27,7 +28,8 @@ install:
 
 script:
   - composer test
-  - if [[ $CS_CHECK == 'true' ]]; then composer cs ; fi
+  - if [[ $CS_CHECK == 'true' ]]; then composer cs-check ; fi
 
 notifications:
-  email: true
+  irc: "irc.freenode.org#zftalk.dev"
+  email: false

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
         "psr/http-message": "^1.0",
         "zendframework/zend-expressive-router": "^1.3.2",
         "zendframework/zend-router": "^3.0",
-        "zendframework/zend-psr7bridge": "^0.2.2"
+        "zendframework/zend-psr7bridge": "^0.2.2",
+        "fig/http-message-util": "^1.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8 || ^5.6",

--- a/composer.json
+++ b/composer.json
@@ -20,12 +20,12 @@
     "require": {
         "php": "^5.6 || ^7.0",
         "psr/http-message": "^1.0",
-        "zendframework/zend-expressive-router": "^1.2",
+        "zendframework/zend-expressive-router": "^1.3.2",
         "zendframework/zend-router": "^3.0",
         "zendframework/zend-psr7bridge": "^0.2.2"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8",
+        "phpunit/phpunit": "^4.8 || ^5.6",
         "zendframework/zend-coding-standard": "~1.0.0"
     },
     "autoload": {
@@ -40,10 +40,10 @@
     },
     "scripts": {
         "check": [
-            "@cs",
+            "@cs-check",
             "@test"
         ],
-        "cs": "phpcs",
+        "cs-check": "phpcs",
         "cs-fix": "phpcbf",
         "test": "phpunit"
     }

--- a/src/ZendRouter.php
+++ b/src/ZendRouter.php
@@ -9,6 +9,7 @@
 
 namespace Zend\Expressive\Router;
 
+use Fig\Http\Message\RequestMethodInterface as RequestMethod;
 use Psr\Http\Message\ServerRequestInterface as PsrRequest;
 use Zend\Expressive\Exception;
 use Zend\Router\Http\TreeRouteStack;
@@ -28,6 +29,14 @@ use Zend\Psr7Bridge\Psr7ServerRequest;
  */
 class ZendRouter implements RouterInterface
 {
+    /**
+     * Implicitly supported HTTP methods on any route.
+     */
+    const HTTP_METHODS_IMPLICIT = [
+        RequestMethod::METHOD_HEAD,
+        RequestMethod::METHOD_OPTIONS,
+    ];
+
     const METHOD_NOT_ALLOWED_ROUTE = 'method_not_allowed';
 
     /**
@@ -185,10 +194,11 @@ class ZendRouter implements RouterInterface
      */
     private function createHttpMethodRoute($route)
     {
+        $methods = array_unique(array_merge($route->getAllowedMethods(), self::HTTP_METHODS_IMPLICIT));
         return [
             'type'    => 'method',
             'options' => [
-                'verb'     => implode(',', $route->getAllowedMethods()),
+                'verb'     => implode(',', $methods),
                 'defaults' => [
                     'middleware' => $route->getMiddleware(),
                 ],


### PR DESCRIPTION
The zend-expressive-router 1.3 series provides changes to support two features:

- populating a `RouteResult` with a `Route` instance, which then provides access to additional `Route` metadata by `RouteResult` consumers.
- marking of `Route` instances as supporting "implicit" `HEAD` and `OPTIONS` operations.

This patch thus does the following:

- Updates to zend-expressive-router 1.3.2+.
- Adds fig/http-message-util, for utilizing the `RequestMethodInterface` constants.
- Updates `injectRoutes()` to memoize the `Route` instance in a `$routes` array.
- Modifies `marshalSuccessResultFromRouteMatch()` to identify the original `Route` instance based on the `RouteMatch` name, and use it to create a `RouteResult` via `RouteResult::fromRoute()`.
- Modifies `createHttpMethodRoute()` to merge in implicit HTTP methods (`HEAD`, `OPTIONS`), ensuring they match the route.

These changes address zendframework/zend-expressive#398 for the zend-router implementation.