### PR TITLE
Drop php 5 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ cache:
 matrix:
   fast_finish: true
   include:
-    - php: 5.6
     - php: 7
       env:
         - CS_CHECK=true

--- a/README.md
+++ b/README.md
@@ -15,4 +15,4 @@ $ composer require zendframework/zend-expressive-zendrouter
 
 ## Documentation
 
-See the Expressive [ZF2 Router documentation](https://zendframework.github.io/zend-expressive/features/router/zf2/).
+See the Expressive [ZF2 Router documentation](https://docs.zendframework.com/zend-expressive/features/router/zf2/).

--- a/composer.json
+++ b/composer.json
@@ -49,6 +49,6 @@
         "cs-check": "phpcs",
         "cs-fix": "phpcbf",
         "license-check": "docheader check src/ test/",
-        "test": "phpunit"
+        "test": "phpunit --colors=always"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "fig/http-message-util": "^1.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8 || ^5.6",
+        "phpunit/phpunit": "^5.7.5",
         "zendframework/zend-coding-standard": "~1.0.0",
         "malukenho/docheader": "^0.1.5"
     },

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         }
     },
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.0",
         "psr/http-message": "^1.0",
         "zendframework/zend-expressive-router": "^1.3.2",
         "zendframework/zend-router": "^3.0",

--- a/src/ZendRouter.php
+++ b/src/ZendRouter.php
@@ -126,7 +126,7 @@ class ZendRouter implements RouterInterface
             ));
         }
 
-        $name = isset($this->routeNameMap[$name]) ? $this->routeNameMap[$name] : $name;
+        $name = $this->routeNameMap[$name] ?? $name;
 
         $options = [
             'name'             => $name,

--- a/src/ZendRouter.php
+++ b/src/ZendRouter.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive-zendrouter/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types = 1);
+
 namespace Zend\Expressive\Router;
 
 use Fig\Http\Message\RequestMethodInterface as RequestMethod;
@@ -137,7 +139,7 @@ class ZendRouter implements RouterInterface
     /**
      * @return TreeRouteStack
      */
-    private function createRouter()
+    private function createRouter() : TreeRouteStack
     {
         return new TreeRouteStack();
     }
@@ -240,7 +242,7 @@ class ZendRouter implements RouterInterface
      * @param string $name
      * @return string
      */
-    private function getMatchedRouteName($name)
+    private function getMatchedRouteName($name) : string
     {
         // Check for <name>/GET:POST style route names; if so, strip off the
         // child route matching the method.


### PR DESCRIPTION
Following changes are:
1. Update PHP version to 7.0 (minimum)
2. Strict type declaration support
3. Simplified logic using null coalesce operator

Add-ons:
1. Updated PHPUnit version to 5.7
2. Supports colored test result
3. Updated documentation link