### PR TITLE
Support zend-expressive-router 2.0

### DIFF
--- a/.docheader
+++ b/.docheader
@@ -1,5 +1,5 @@
 /**
  * @see       https://github.com/zendframework/zend-expressive-zendrouter for the canonical source repository
- * @copyright Copyright (c) %regexp:(20\d{2}-)?%%year% Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) %regexp:(20\d{2}-)?20\d{2}% Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-zendrouter/blob/master/LICENSE.md New BSD License
  */

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
     "require-dev": {
         "phpunit/phpunit": "^4.8 || ^5.6",
         "zendframework/zend-coding-standard": "~1.0.0",
-        "malukenho/docheader": "^0.1.5"
+        "malukenho/docheader": "^0.1.5",
+        "zendframework/zend-i18n": "^2.7"
     },
     "autoload": {
       "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "require": {
         "php": "^5.6 || ^7.0",
         "psr/http-message": "^1.0",
-        "zendframework/zend-expressive-router": "^1.3.2",
+        "zendframework/zend-expressive-router": "^2.0",
         "zendframework/zend-router": "^3.0",
         "zendframework/zend-psr7bridge": "^0.2.2",
         "fig/http-message-util": "^1.1"

--- a/src/ZendRouter.php
+++ b/src/ZendRouter.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-zendrouter for the canonical source repository
- * @copyright Copyright (c) 2015-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-zendrouter/blob/master/LICENSE.md New BSD License
  */
 
@@ -10,9 +10,9 @@ namespace Zend\Expressive\Router;
 use Fig\Http\Message\RequestMethodInterface as RequestMethod;
 use Psr\Http\Message\ServerRequestInterface as PsrRequest;
 use Zend\Expressive\Exception;
+use Zend\Psr7Bridge\Psr7ServerRequest;
 use Zend\Router\Http\TreeRouteStack;
 use Zend\Router\RouteMatch;
-use Zend\Psr7Bridge\Psr7ServerRequest;
 
 /**
  * Router implementation that consumes zend-mvc TreeRouteStack.
@@ -112,7 +112,7 @@ class ZendRouter implements RouterInterface
     /**
      * {@inheritDoc}
      */
-    public function generateUri($name, array $substitutions = [])
+    public function generateUri($name, array $substitutions = [], array $options = [])
     {
         // Must inject routes prior to generating URIs.
         $this->injectRoutes();
@@ -126,10 +126,10 @@ class ZendRouter implements RouterInterface
 
         $name = isset($this->routeNameMap[$name]) ? $this->routeNameMap[$name] : $name;
 
-        $options = [
+        $options = array_merge($options, [
             'name'             => $name,
             'only_return_path' => true,
-        ];
+        ]);
 
         return $this->zendRouter->assemble($substitutions, $options);
     }

--- a/test/ZendRouterTest.php
+++ b/test/ZendRouterTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-zendrouter for the canonical source repository
- * @copyright Copyright (c) 2015-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-zendrouter/blob/master/LICENSE.md New BSD License
  */
 
@@ -15,6 +15,7 @@ use Zend\Expressive\Router\Route;
 use Zend\Expressive\Router\RouteResult;
 use Zend\Expressive\Router\ZendRouter;
 use Zend\Http\Request as ZendRequest;
+use Zend\I18n\Translator\TranslatorInterface;
 use Zend\Router\Http\TreeRouteStack;
 use Zend\Router\RouteMatch;
 
@@ -423,5 +424,24 @@ class ZendRouterTest extends TestCase
         $this->assertInstanceOf(RouteResult::class, $result);
         $this->assertTrue($result->isSuccess());
         $this->assertSame($route, $result->getMatchedRoute());
+    }
+
+    public function testUriGenerationMayUseOptions()
+    {
+        $route = new Route('/de/{lang}', 'bar', [RequestMethod::METHOD_PUT], 'test');
+
+        $router = new ZendRouter();
+        $router->addRoute($route);
+
+        $translator = $this->prophesize(TranslatorInterface::class);
+        $translator->translate('lang', 'uri', 'de')->willReturn('found');
+
+        $uri = $router->generateUri('test', [], [
+            'translator'  => $translator->reveal(),
+            'locale'      => 'de',
+            'text_domain' => 'uri',
+        ]);
+
+        $this->assertEquals('/de/found', $uri);
     }
 }


### PR DESCRIPTION
Updated zend-expressive-router to 2.0.

Added `$options` argument based on new interface spec; `$options` passed to `generateUri()` are now passed to the underlying router in order to generate the final URI.