### PR TITLE
added files to be ignored during export

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,3 +5,9 @@
 .travis.yml export-ignore
 phpunit.xml.dist export-ignore
 phpcs.xml export-ignore
+.coveralls.yml export-ignore
+.docheader export-ignore
+CONDUCT.md export-ignore
+CONTRIBUTING.md export-ignore
+README.md export-ignore
+CHANGELOG.md export-ignore


### PR DESCRIPTION
Additional files to be ignored during export:

- .coveralls.yml export-ignore
- .docheader export-ignore
- CONDUCT.md export-ignore
- CONTRIBUTING.md export-ignore
- README.md export-ignore
- CHANGELOG.md export-ignore