### PR TITLE
PHP 7.1 - typehints, return types, strict types

### DIFF
--- a/.docheader
+++ b/.docheader
@@ -3,4 +3,5 @@
  * @copyright Copyright (c) %regexp:(20\d{2}-)?20\d{2}% Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-zendrouter/blob/master/LICENSE.md New BSD License
  */
+
 declare(strict_types=1);

--- a/.docheader
+++ b/.docheader
@@ -1,5 +1,5 @@
 /**
  * @see       https://github.com/zendframework/zend-expressive-zendrouter for the canonical source repository
- * @copyright Copyright (c) %regexp:(20\d{2}-)?20\d{2}% Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) %regexp:(20\d{2}-)?20\d{2}% Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-zendrouter/blob/master/LICENSE.md New BSD License
  */

--- a/.docheader
+++ b/.docheader
@@ -3,3 +3,4 @@
  * @copyright Copyright (c) %regexp:(20\d{2}-)?20\d{2}% Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-zendrouter/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,26 +13,6 @@ env:
 
 matrix:
   include:
-    - php: 5.6
-      env:
-        - DEPS=lowest
-    - php: 5.6
-      env:
-        - DEPS=locked
-        - LEGACY_DEPS="phpunit/phpunit"
-    - php: 5.6
-      env:
-        - DEPS=latest
-    - php: 7
-      env:
-        - DEPS=lowest
-    - php: 7
-      env:
-        - DEPS=locked
-        - LEGACY_DEPS="phpunit/phpunit"
-    - php: 7
-      env:
-        - DEPS=latest
     - php: 7.1
       env:
         - DEPS=lowest
@@ -56,11 +36,9 @@ matrix:
 
 before_install:
   - if [[ $TEST_COVERAGE != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi
-  - travis_retry composer self-update
 
 install:
-  - travis_retry composer install $COMPOSER_ARGS --ignore-platform-reqs
-  - if [[ $LEGACY_DEPS != '' ]]; then travis_retry composer update $COMPOSER_ARGS --with-dependencies $LEGACY_DEPS ; fi
+  - travis_retry composer install $COMPOSER_ARGS
   - if [[ $DEPS == 'latest' ]]; then travis_retry composer update $COMPOSER_ARGS ; fi
   - if [[ $DEPS == 'lowest' ]]; then travis_retry composer update --prefer-lowest --prefer-stable $COMPOSER_ARGS ; fi
   - if [[ $TEST_COVERAGE == 'true' ]]; then travis_retry composer require --dev $COMPOSER_ARGS $COVERAGE_DEPS ; fi

--- a/composer.json
+++ b/composer.json
@@ -19,23 +19,17 @@
         "slack": "https://zendframework-slack.herokuapp.com",
         "forum": "https://discourse.zendframework.com/c/questions/expressive"
     },
-    "repositories": [
-        {
-            "type": "git",
-            "url": "https://github.com/webimpress/zend-expressive-router.git"
-        }
-    ],
     "require": {
         "php": "^7.1",
         "fig/http-message-util": "^1.1.2",
         "psr/http-message": "^1.0.1",
-        "zendframework/zend-expressive-router": "dev-feature/php-7.1",
+        "zendframework/zend-expressive-router": "^3.0.0@dev",
         "zendframework/zend-psr7bridge": "^0.2.2 || ^1.0.0",
         "zendframework/zend-router": "^3.0.2"
     },
     "require-dev": {
         "malukenho/docheader": "^0.1.6",
-        "phpunit/phpunit": "^6.5.2",
+        "phpunit/phpunit": "^6.5.3",
         "zendframework/zend-coding-standard": "~1.0.0",
         "zendframework/zend-i18n": "^2.7.4"
     },

--- a/composer.json
+++ b/composer.json
@@ -19,19 +19,25 @@
         "slack": "https://zendframework-slack.herokuapp.com",
         "forum": "https://discourse.zendframework.com/c/questions/expressive"
     },
+    "repositories": [
+        {
+            "type": "git",
+            "url": "https://github.com/webimpress/zend-expressive-router.git"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.1",
         "fig/http-message-util": "^1.1.2",
         "psr/http-message": "^1.0.1",
-        "zendframework/zend-expressive-router": "^2.1",
+        "zendframework/zend-expressive-router": "dev-feature/php-7.1",
         "zendframework/zend-psr7bridge": "^0.2.2 || ^1.0.0",
         "zendframework/zend-router": "^3.0.2"
     },
     "require-dev": {
-        "malukenho/docheader": "^0.1.5",
-        "phpunit/phpunit": "^5.7.23 || ^6.4.3",
+        "malukenho/docheader": "^0.1.6",
+        "phpunit/phpunit": "^6.5.2",
         "zendframework/zend-coding-standard": "~1.0.0",
-        "zendframework/zend-i18n": "^2.7.3"
+        "zendframework/zend-i18n": "^2.7.4"
     },
     "autoload": {
         "psr-4": {
@@ -49,7 +55,8 @@
     "extra": {
         "branch-alias": {
             "dev-master": "2.0-dev",
-            "dev-develop": "2.1-dev"
+            "dev-develop": "2.1-dev",
+            "dev-release-3.0.0": "3.0.x-dev"
         }
     },
     "scripts": {

--- a/composer.lock
+++ b/composer.lock
@@ -395,7 +395,7 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/webimpress/zend-expressive-router.git",
-                "reference": "5b5c921592a21935cd58f92761f5e110746d00e3"
+                "reference": "d615c31006c9b67d2bfc2b32dce179d3279f67dc"
             },
             "require": {
                 "fig/http-message-util": "^1.1.2",
@@ -477,7 +477,7 @@
                 "slack": "https://zendframework-slack.herokuapp.com",
                 "forum": "https://discourse.zendframework.com/c/questions/expressive"
             },
-            "time": "2017-12-06T07:14:57+00:00"
+            "time": "2017-12-06T21:12:31+00:00"
         },
         {
             "name": "zendframework/zend-http",
@@ -1385,16 +1385,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "5.2.4",
+            "version": "5.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "033ec97498cf530cc1be4199264cad568b19be26"
+                "reference": "661f34d0bd3f1a7225ef491a70a020ad23a057a1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/033ec97498cf530cc1be4199264cad568b19be26",
-                "reference": "033ec97498cf530cc1be4199264cad568b19be26",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/661f34d0bd3f1a7225ef491a70a020ad23a057a1",
+                "reference": "661f34d0bd3f1a7225ef491a70a020ad23a057a1",
                 "shasum": ""
             },
             "require": {
@@ -1410,7 +1410,6 @@
                 "theseer/tokenizer": "^1.1"
             },
             "require-dev": {
-                "ext-xdebug": "^2.5",
                 "phpunit/phpunit": "^6.0"
             },
             "suggest": {
@@ -1419,7 +1418,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.2.x-dev"
+                    "dev-master": "5.3.x-dev"
                 }
             },
             "autoload": {
@@ -1434,7 +1433,7 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
+                    "email": "sebastian@phpunit.de",
                     "role": "lead"
                 }
             ],
@@ -1445,7 +1444,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-11-27T09:00:30+00:00"
+            "time": "2017-12-06T09:29:45+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -1635,16 +1634,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "6.5.2",
+            "version": "6.5.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "24b708f2fd725bcef1c8153b366043381aa324f2"
+                "reference": "882e886cc928a0abd3c61282b2a64026237d14a4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/24b708f2fd725bcef1c8153b366043381aa324f2",
-                "reference": "24b708f2fd725bcef1c8153b366043381aa324f2",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/882e886cc928a0abd3c61282b2a64026237d14a4",
+                "reference": "882e886cc928a0abd3c61282b2a64026237d14a4",
                 "shasum": ""
             },
             "require": {
@@ -1658,7 +1657,7 @@
                 "phar-io/version": "^1.0",
                 "php": "^7.0",
                 "phpspec/prophecy": "^1.7",
-                "phpunit/php-code-coverage": "^5.2.3",
+                "phpunit/php-code-coverage": "^5.3",
                 "phpunit/php-file-iterator": "^1.4.3",
                 "phpunit/php-text-template": "^1.2.1",
                 "phpunit/php-timer": "^1.0.9",
@@ -1715,7 +1714,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-12-02T05:36:24+00:00"
+            "time": "2017-12-06T09:42:03+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "8eb039437d3f8566f7b87133d488ff35",
+    "content-hash": "dbeaba48acfd21449998bcc49342405b",
     "packages": [
         {
             "name": "container-interop/container-interop",
@@ -391,11 +391,17 @@
         },
         {
             "name": "zendframework/zend-expressive-router",
-            "version": "dev-feature/php-7.1",
+            "version": "dev-release-3.0.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/webimpress/zend-expressive-router.git",
-                "reference": "d615c31006c9b67d2bfc2b32dce179d3279f67dc"
+                "url": "https://github.com/zendframework/zend-expressive-router.git",
+                "reference": "6b2cfc3bc9ca787effccbabe190bc0aee0c62b68"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-expressive-router/zipball/6b2cfc3bc9ca787effccbabe190bc0aee0c62b68",
+                "reference": "6b2cfc3bc9ca787effccbabe190bc0aee0c62b68",
+                "shasum": ""
             },
             "require": {
                 "fig/http-message-util": "^1.1.2",
@@ -426,58 +432,22 @@
                     "Zend\\Expressive\\Router\\": "src/"
                 }
             },
-            "autoload-dev": {
-                "psr-4": {
-                    "ZendTest\\Expressive\\Router\\": "test/"
-                }
-            },
-            "scripts": {
-                "check": [
-                    "@license-check",
-                    "@cs-check",
-                    "@test"
-                ],
-                "cs-check": [
-                    "phpcs"
-                ],
-                "cs-fix": [
-                    "phpcbf"
-                ],
-                "test": [
-                    "phpunit --colors=always"
-                ],
-                "test-coverage": [
-                    "phpunit --colors=always --coverage-clover clover.xml"
-                ],
-                "upload-coverage": [
-                    "coveralls -v"
-                ],
-                "license-check": [
-                    "docheader check src/ test/"
-                ]
-            },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "BSD-3-Clause"
             ],
             "description": "Router subcomponent for Expressive",
             "keywords": [
+                "ZendFramework",
                 "expressive",
                 "http",
                 "middleware",
                 "psr",
                 "psr-7",
                 "zend-expressive",
-                "zendframework",
                 "zf"
             ],
-            "support": {
-                "issues": "https://github.com/zendframework/zend-expressive-router/issues",
-                "source": "https://github.com/zendframework/zend-expressive-router",
-                "rss": "https://github.com/zendframework/zend-expressive-router/releases.atom",
-                "slack": "https://zendframework-slack.herokuapp.com",
-                "forum": "https://discourse.zendframework.com/c/questions/expressive"
-            },
-            "time": "2017-12-06T21:12:31+00:00"
+            "time": "2017-12-06T21:19:34+00:00"
         },
         {
             "name": "zendframework/zend-http",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "5d1f568a603e5f705c16bafd56bf72da",
+    "content-hash": "8eb039437d3f8566f7b87133d488ff35",
     "packages": [
         {
             "name": "container-interop/container-interop",
@@ -88,22 +88,78 @@
             "time": "2017-02-09T16:10:21+00:00"
         },
         {
-            "name": "http-interop/http-middleware",
-            "version": "0.5.0",
+            "name": "http-interop/http-server-handler",
+            "version": "1.0.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/http-interop/http-middleware.git",
-                "reference": "b49e1f9f6c584e704317b563302e566b8ce11858"
+                "url": "https://github.com/http-interop/http-server-handler.git",
+                "reference": "931a6495fb1b6005c9b4abc4dd11fb12a2a8103b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/http-interop/http-middleware/zipball/b49e1f9f6c584e704317b563302e566b8ce11858",
-                "reference": "b49e1f9f6c584e704317b563302e566b8ce11858",
+                "url": "https://api.github.com/repos/http-interop/http-server-handler/zipball/931a6495fb1b6005c9b4abc4dd11fb12a2a8103b",
+                "reference": "931a6495fb1b6005c9b4abc4dd11fb12a2a8103b",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.0",
+                "php": ">=7.0",
                 "psr/http-message": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Interop\\Http\\Server\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP server-side request handler",
+            "keywords": [
+                "handler",
+                "http",
+                "psr",
+                "psr-15",
+                "psr-7",
+                "request",
+                "response",
+                "server"
+            ],
+            "time": "2017-11-09T18:35:22+00:00"
+        },
+        {
+            "name": "http-interop/http-server-middleware",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/http-interop/http-server-middleware.git",
+                "reference": "e605a7f47a002e857a3b9bb992010e2f859e4560"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/http-interop/http-server-middleware/zipball/e605a7f47a002e857a3b9bb992010e2f859e4560",
+                "reference": "e605a7f47a002e857a3b9bb992010e2f859e4560",
+                "shasum": ""
+            },
+            "require": {
+                "http-interop/http-server-handler": "^1.0",
+                "php": ">=7.0",
+                "psr/http-message": "^1.0"
+            },
+            "replace": {
+                "http-interop/http-middleware": ">=0.5"
             },
             "type": "library",
             "extra": {
@@ -136,8 +192,7 @@
                 "request",
                 "response"
             ],
-            "abandoned": "http-interop/http-server-middleware",
-            "time": "2017-09-18T15:27:03+00:00"
+            "time": "2017-11-09T21:42:30+00:00"
         },
         {
             "name": "psr/container",
@@ -239,98 +294,6 @@
             "time": "2016-08-06T14:39:51+00:00"
         },
         {
-            "name": "webimpress/composer-extra-dependency",
-            "version": "0.2.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/webimpress/composer-extra-dependency.git",
-                "reference": "31fa56391d30f03b1180c87610cbe22254780ad9"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/webimpress/composer-extra-dependency/zipball/31fa56391d30f03b1180c87610cbe22254780ad9",
-                "reference": "31fa56391d30f03b1180c87610cbe22254780ad9",
-                "shasum": ""
-            },
-            "require": {
-                "composer-plugin-api": "^1.1",
-                "php": "^5.6 || ^7.0"
-            },
-            "require-dev": {
-                "composer/composer": "^1.5.2",
-                "mikey179/vfsstream": "^1.6.5",
-                "phpunit/phpunit": "^5.7.22 || ^6.4.1",
-                "zendframework/zend-coding-standard": "~1.0.0"
-            },
-            "type": "composer-plugin",
-            "extra": {
-                "class": "Webimpress\\ComposerExtraDependency\\Plugin"
-            },
-            "autoload": {
-                "psr-4": {
-                    "Webimpress\\ComposerExtraDependency\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-2-Clause"
-            ],
-            "description": "Composer plugin to require extra dependencies",
-            "homepage": "https://github.com/webimpress/composer-extra-dependency",
-            "keywords": [
-                "composer",
-                "dependency",
-                "webimpress"
-            ],
-            "time": "2017-10-17T17:15:14+00:00"
-        },
-        {
-            "name": "webimpress/http-middleware-compatibility",
-            "version": "0.1.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/webimpress/http-middleware-compatibility.git",
-                "reference": "8ed1c2c7523dce0035b98bc4f3a73ca9cd1d3717"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/webimpress/http-middleware-compatibility/zipball/8ed1c2c7523dce0035b98bc4f3a73ca9cd1d3717",
-                "reference": "8ed1c2c7523dce0035b98bc4f3a73ca9cd1d3717",
-                "shasum": ""
-            },
-            "require": {
-                "http-interop/http-middleware": "^0.1.1 || ^0.2 || ^0.3 || ^0.4.1 || ^0.5",
-                "php": "^5.6 || ^7.0",
-                "webimpress/composer-extra-dependency": "^0.2.2"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^5.7.23 || ^6.4.3"
-            },
-            "type": "library",
-            "extra": {
-                "dependency": [
-                    "http-interop/http-middleware"
-                ]
-            },
-            "autoload": {
-                "files": [
-                    "autoload/http-middleware.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-2-Clause"
-            ],
-            "description": "Compatibility library for Draft PSR-15 HTTP Middleware",
-            "homepage": "https://github.com/webimpress/http-middleware-compatibility",
-            "keywords": [
-                "middleware",
-                "psr-15",
-                "webimpress"
-            ],
-            "time": "2017-10-17T17:31:10+00:00"
-        },
-        {
             "name": "zendframework/zend-diactoros",
             "version": "1.6.1",
             "source": {
@@ -428,27 +391,21 @@
         },
         {
             "name": "zendframework/zend-expressive-router",
-            "version": "2.2.0",
+            "version": "dev-feature/php-7.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/zendframework/zend-expressive-router.git",
-                "reference": "f6eac53d39cdbf7b6db11b3e6bb3565896633de4"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-expressive-router/zipball/f6eac53d39cdbf7b6db11b3e6bb3565896633de4",
-                "reference": "f6eac53d39cdbf7b6db11b3e6bb3565896633de4",
-                "shasum": ""
+                "url": "https://github.com/webimpress/zend-expressive-router.git",
+                "reference": "5b5c921592a21935cd58f92761f5e110746d00e3"
             },
             "require": {
                 "fig/http-message-util": "^1.1.2",
-                "php": "^5.6 || ^7.0",
-                "psr/http-message": "^1.0.1",
-                "webimpress/http-middleware-compatibility": "^0.1.1"
+                "http-interop/http-server-middleware": "^1.0.1",
+                "php": "^7.1",
+                "psr/http-message": "^1.0.1"
             },
             "require-dev": {
                 "malukenho/docheader": "^0.1.5",
-                "phpunit/phpunit": "^6.0.8 || ^5.7.15",
+                "phpunit/phpunit": "^6.4.4",
                 "zendframework/zend-coding-standard": "~1.0.0"
             },
             "suggest": {
@@ -459,8 +416,9 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.2-dev",
-                    "dev-develop": "2.3-dev"
+                    "dev-master": "2.2.x-dev",
+                    "dev-develop": "2.3.x-dev",
+                    "dev-release-3.0.0": "3.0.x-dev"
                 }
             },
             "autoload": {
@@ -468,7 +426,36 @@
                     "Zend\\Expressive\\Router\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "ZendTest\\Expressive\\Router\\": "test/"
+                }
+            },
+            "scripts": {
+                "check": [
+                    "@license-check",
+                    "@cs-check",
+                    "@test"
+                ],
+                "cs-check": [
+                    "phpcs"
+                ],
+                "cs-fix": [
+                    "phpcbf"
+                ],
+                "test": [
+                    "phpunit --colors=always"
+                ],
+                "test-coverage": [
+                    "phpunit --colors=always --coverage-clover clover.xml"
+                ],
+                "upload-coverage": [
+                    "coveralls -v"
+                ],
+                "license-check": [
+                    "docheader check src/ test/"
+                ]
+            },
             "license": [
                 "BSD-3-Clause"
             ],
@@ -478,9 +465,19 @@
                 "http",
                 "middleware",
                 "psr",
-                "psr-7"
+                "psr-7",
+                "zend-expressive",
+                "zendframework",
+                "zf"
             ],
-            "time": "2017-10-09T18:44:11+00:00"
+            "support": {
+                "issues": "https://github.com/zendframework/zend-expressive-router/issues",
+                "source": "https://github.com/zendframework/zend-expressive-router",
+                "rss": "https://github.com/zendframework/zend-expressive-router/releases.atom",
+                "slack": "https://zendframework-slack.herokuapp.com",
+                "forum": "https://discourse.zendframework.com/c/questions/expressive"
+            },
+            "time": "2017-12-06T07:14:57+00:00"
         },
         {
             "name": "zendframework/zend-http",
@@ -2885,11 +2882,13 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "zendframework/zend-expressive-router": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^5.6 || ^7.0"
+        "php": "^7.1"
     },
     "platform-dev": []
 }

--- a/src/ZendRouter.php
+++ b/src/ZendRouter.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-zendrouter/blob/master/LICENSE.md New BSD License
  */
+
 declare(strict_types=1);
 
 namespace Zend\Expressive\Router;

--- a/src/ZendRouter.php
+++ b/src/ZendRouter.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-zendrouter/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 namespace Zend\Expressive\Router;
 

--- a/src/ZendRouter.php
+++ b/src/ZendRouter.php
@@ -31,12 +31,12 @@ class ZendRouter implements RouterInterface
     /**
      * Implicitly supported HTTP methods on any route.
      */
-    const HTTP_METHODS_IMPLICIT = [
+    public const HTTP_METHODS_IMPLICIT = [
         RequestMethod::METHOD_HEAD,
         RequestMethod::METHOD_OPTIONS,
     ];
 
-    const METHOD_NOT_ALLOWED_ROUTE = 'method_not_allowed';
+    public const METHOD_NOT_ALLOWED_ROUTE = 'method_not_allowed';
 
     /**
      * Store the HTTP methods allowed for each path.

--- a/src/ZendRouter.php
+++ b/src/ZendRouter.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-zendrouter for the canonical source repository
- * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-zendrouter/blob/master/LICENSE.md New BSD License
  */
 

--- a/src/ZendRouter.php
+++ b/src/ZendRouter.php
@@ -73,8 +73,6 @@ class ZendRouter implements RouterInterface
      * Constructor.
      *
      * Lazy instantiates a TreeRouteStack if none is provided.
-     *
-     * @param null|TreeRouteStack $router
      */
     public function __construct(TreeRouteStack $router = null)
     {
@@ -85,18 +83,12 @@ class ZendRouter implements RouterInterface
         $this->zendRouter = $router;
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function addRoute(Route $route)
+    public function addRoute(Route $route) : void
     {
         $this->routesToInject[] = $route;
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function match(PsrRequest $request)
+    public function match(PsrRequest $request) : RouteResult
     {
         // Must inject routes prior to matching.
         $this->injectRoutes();
@@ -110,10 +102,7 @@ class ZendRouter implements RouterInterface
         return $this->marshalSuccessResultFromRouteMatch($match, $request);
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function generateUri($name, array $substitutions = [], array $options = [])
+    public function generateUri(string $name, array $substitutions = [], array $options = []) : string
     {
         // Must inject routes prior to generating URIs.
         $this->injectRoutes();
@@ -135,10 +124,7 @@ class ZendRouter implements RouterInterface
         return $this->zendRouter->assemble($substitutions, $options);
     }
 
-    /**
-     * @return TreeRouteStack
-     */
-    private function createRouter()
+    private function createRouter() : TreeRouteStack
     {
         return new TreeRouteStack();
     }
@@ -146,11 +132,9 @@ class ZendRouter implements RouterInterface
     /**
      * Create a successful RouteResult from the given RouteMatch.
      *
-     * @param RouteMatch $match
      * @param PsrRequest $request Current HTTP request
-     * @return RouteResult
      */
-    private function marshalSuccessResultFromRouteMatch(RouteMatch $match, PsrRequest $request)
+    private function marshalSuccessResultFromRouteMatch(RouteMatch $match, PsrRequest $request) : RouteResult
     {
         $params = $match->getParams();
 
@@ -187,13 +171,11 @@ class ZendRouter implements RouterInterface
 
     /**
      * Create route configuration for matching one or more HTTP methods.
-     *
-     * @param Route $route
-     * @return array
      */
-    private function createHttpMethodRoute($route)
+    private function createHttpMethodRoute(Route $route) : array
     {
         $methods = array_unique(array_merge($route->getAllowedMethods(), self::HTTP_METHODS_IMPLICIT));
+
         return [
             'type'    => 'method',
             'options' => [
@@ -212,11 +194,8 @@ class ZendRouter implements RouterInterface
      * essentially, this is a route that will always match, but *after* the
      * HTTP method route has already failed. By checking for this route later,
      * we can return a 405 response with the allowed methods.
-     *
-     * @param string $path
-     * @return array
      */
-    private function createMethodNotAllowedRoute($path)
+    private function createMethodNotAllowedRoute(string $path) : array
     {
         return [
             'type'     => 'regex',
@@ -237,11 +216,8 @@ class ZendRouter implements RouterInterface
      * Routes will generally match the child HTTP method routes, which will not
      * match the names they were registered with; this method strips the method
      * route name if present.
-     *
-     * @param string $name
-     * @return string
      */
-    private function getMatchedRouteName($name)
+    private function getMatchedRouteName(string $name) : string
     {
         // Check for <name>/GET:POST style route names; if so, strip off the
         // child route matching the method.
@@ -256,7 +232,7 @@ class ZendRouter implements RouterInterface
     /**
      * Inject any unprocessed routes into the underlying router implementation.
      */
-    private function injectRoutes()
+    private function injectRoutes() : void
     {
         foreach ($this->routesToInject as $index => $route) {
             $this->injectRoute($route);
@@ -267,10 +243,8 @@ class ZendRouter implements RouterInterface
 
     /**
      * Inject route into the underlying router implemetation.
-     *
-     * @param Route $route
      */
-    private function injectRoute(Route $route)
+    private function injectRoute(Route $route) : void
     {
         $name    = $route->getName();
         $path    = $route->getPath();

--- a/test/ZendRouterTest.php
+++ b/test/ZendRouterTest.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-zendrouter/blob/master/LICENSE.md New BSD License
  */
+declare(strict_types=1);
 
 namespace ZendTest\Expressive\Router;
 

--- a/test/ZendRouterTest.php
+++ b/test/ZendRouterTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-zendrouter for the canonical source repository
- * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-zendrouter/blob/master/LICENSE.md New BSD License
  */
 

--- a/test/ZendRouterTest.php
+++ b/test/ZendRouterTest.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-zendrouter/blob/master/LICENSE.md New BSD License
  */
+
 declare(strict_types=1);
 
 namespace ZendTest\Expressive\Router;


### PR DESCRIPTION
The PR destination should be changes once branch `release-3.0.0` is created.

Also we should update `zend-expressive-router` to `^3.0.0@dev` once https://github.com/zendframework/zend-expressive-router/pull/41 is merged. 