### PR TITLE
Fixed matched route name in case when there are no allowed methods

### DIFF
--- a/src/ZendRouter.php
+++ b/src/ZendRouter.php
@@ -229,7 +229,7 @@ class ZendRouter implements RouterInterface
         }
 
         // Otherwise, just use the name.
-        return $name;
+        return rtrim($name, '/');
     }
 
     /**

--- a/test/ZendRouterTest.php
+++ b/test/ZendRouterTest.php
@@ -266,6 +266,46 @@ class ZendRouterTest extends TestCase
         $this->assertEquals($middleware, $result->getMatchedMiddleware());
     }
 
+    public function testMatchedRouteNameNoAllowedMethods()
+    {
+        $middleware = $this->getMiddleware();
+
+        $zendRouter = new ZendRouter();
+        $zendRouter->addRoute(new Route('/foo', $middleware, [], '/foo'));
+
+        $request = new ServerRequest(
+            ['REQUEST_METHOD' => RequestMethod::METHOD_HEAD],
+            [],
+            '/foo',
+            RequestMethod::METHOD_HEAD
+        );
+        $result = $zendRouter->match($request);
+        $this->assertInstanceOf(RouteResult::class, $result);
+        $this->assertTrue($result->isSuccess());
+        $this->assertSame('/foo', $result->getMatchedRouteName());
+        $this->assertSame($middleware, $result->getMatchedMiddleware());
+    }
+
+    public function testMatchedRouteNameWhenGetMethodAllowed()
+    {
+        $middleware = $this->getMiddleware();
+
+        $zendRouter = new ZendRouter();
+        $zendRouter->addRoute(new Route('/foo', $middleware, [RequestMethod::METHOD_GET], '/foo'));
+
+        $request = new ServerRequest(
+            ['REQUEST_METHOD' => RequestMethod::METHOD_GET],
+            [],
+            '/foo',
+            RequestMethod::METHOD_GET
+        );
+        $result = $zendRouter->match($request);
+        $this->assertInstanceOf(RouteResult::class, $result);
+        $this->assertTrue($result->isSuccess());
+        $this->assertSame('/foo', $result->getMatchedRouteName());
+        $this->assertSame($middleware, $result->getMatchedMiddleware());
+    }
+
     /**
      * @group match
      */


### PR DESCRIPTION
This fix is to conform behaviour with zend-expressive-aurarouter
and zend-expressive-fastrouter, we should have matching path in that case

