### PR TITLE
Ensure router passes integration tests for implicit HEAD/OPTIONS requests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,17 +19,11 @@
         "slack": "https://zendframework-slack.herokuapp.com",
         "forum": "https://discourse.zendframework.com/c/questions/expressive"
     },
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "git://github.com/webimpress/zend-expressive-router.git"
-        }
-    ],
     "require": {
         "php": "^7.1",
         "fig/http-message-util": "^1.1.2",
         "psr/http-message": "^1.0.1",
-        "zendframework/zend-expressive-router": "dev-head-options-requests as 3.0.0rc2",
+        "zendframework/zend-expressive-router": "^3.0.0rc2",
         "zendframework/zend-psr7bridge": "^0.2.2 || ^1.0.0",
         "zendframework/zend-router": "^3.0.2"
     },

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "repositories": [
         {
             "type": "vcs",
-            "url": "https://github.com/webimpress/zend-expressive-router"
+            "url": "git://github.com/webimpress/zend-expressive-router.git"
         }
     ],
     "require": {

--- a/composer.json
+++ b/composer.json
@@ -19,11 +19,17 @@
         "slack": "https://zendframework-slack.herokuapp.com",
         "forum": "https://discourse.zendframework.com/c/questions/expressive"
     },
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/webimpress/zend-expressive-router"
+        }
+    ],
     "require": {
         "php": "^7.1",
         "fig/http-message-util": "^1.1.2",
         "psr/http-message": "^1.0.1",
-        "zendframework/zend-expressive-router": "^3.0.0rc1",
+        "zendframework/zend-expressive-router": "dev-head-options-requests as 3.0.0rc2",
         "zendframework/zend-psr7bridge": "^0.2.2 || ^1.0.0",
         "zendframework/zend-router": "^3.0.2"
     },
@@ -31,7 +37,8 @@
         "malukenho/docheader": "^0.1.6",
         "phpunit/phpunit": "^7.0.2",
         "zendframework/zend-coding-standard": "~1.0.0",
-        "zendframework/zend-i18n": "^2.7.4"
+        "zendframework/zend-i18n": "^2.7.4",
+        "zendframework/zend-stratigility": "^3.0.0rc1"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "83aa8a8d660379373928b9c3f549627b",
+    "content-hash": "8049346221ac7fc5e2ce5da9d5345a50",
     "packages": [
         {
             "name": "container-interop/container-interop",
@@ -394,12 +394,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/webimpress/zend-expressive-router.git",
-                "reference": "c1e704096b37897410414246a09bd00e186e41c7"
+                "reference": "2fcc7d610b0394417d99c682b5451e2dd049f1c0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webimpress/zend-expressive-router/zipball/c1e704096b37897410414246a09bd00e186e41c7",
-                "reference": "c1e704096b37897410414246a09bd00e186e41c7",
+                "url": "https://api.github.com/repos/webimpress/zend-expressive-router/zipball/2fcc7d610b0394417d99c682b5451e2dd049f1c0",
+                "reference": "2fcc7d610b0394417d99c682b5451e2dd049f1c0",
                 "shasum": ""
             },
             "require": {
@@ -485,7 +485,7 @@
                 "slack": "https://zendframework-slack.herokuapp.com",
                 "forum": "https://discourse.zendframework.com/c/questions/expressive"
             },
-            "time": "2018-03-06T17:43:52+00:00"
+            "time": "2018-03-06T20:55:46+00:00"
         },
         {
             "name": "zendframework/zend-http",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "8049346221ac7fc5e2ce5da9d5345a50",
+    "content-hash": "a8b4634d72581ecace29210f9d18ca7c",
     "packages": [
         {
             "name": "container-interop/container-interop",
@@ -390,16 +390,16 @@
         },
         {
             "name": "zendframework/zend-expressive-router",
-            "version": "dev-head-options-requests",
+            "version": "3.0.0rc2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/webimpress/zend-expressive-router.git",
-                "reference": "2fcc7d610b0394417d99c682b5451e2dd049f1c0"
+                "url": "https://github.com/zendframework/zend-expressive-router.git",
+                "reference": "97ea9940c72222586e832913529b097ddcc0b2e4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webimpress/zend-expressive-router/zipball/2fcc7d610b0394417d99c682b5451e2dd049f1c0",
-                "reference": "2fcc7d610b0394417d99c682b5451e2dd049f1c0",
+                "url": "https://api.github.com/repos/zendframework/zend-expressive-router/zipball/97ea9940c72222586e832913529b097ddcc0b2e4",
+                "reference": "97ea9940c72222586e832913529b097ddcc0b2e4",
                 "shasum": ""
             },
             "require": {
@@ -437,55 +437,22 @@
                     "Zend\\Expressive\\Router\\": "src/"
                 }
             },
-            "autoload-dev": {
-                "psr-4": {
-                    "ZendTest\\Expressive\\Router\\": "test/"
-                }
-            },
-            "scripts": {
-                "check": [
-                    "@license-check",
-                    "@cs-check",
-                    "@test"
-                ],
-                "cs-check": [
-                    "phpcs"
-                ],
-                "cs-fix": [
-                    "phpcbf"
-                ],
-                "test": [
-                    "phpunit --colors=always"
-                ],
-                "test-coverage": [
-                    "phpunit --colors=always --coverage-clover clover.xml"
-                ],
-                "license-check": [
-                    "docheader check src/ test/"
-                ]
-            },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "BSD-3-Clause"
             ],
             "description": "Router subcomponent for Expressive",
             "keywords": [
+                "ZendFramework",
                 "expressive",
                 "http",
                 "middleware",
                 "psr",
                 "psr-7",
                 "zend-expressive",
-                "zendframework",
                 "zf"
             ],
-            "support": {
-                "issues": "https://github.com/zendframework/zend-expressive-router/issues",
-                "source": "https://github.com/zendframework/zend-expressive-router",
-                "rss": "https://github.com/zendframework/zend-expressive-router/releases.atom",
-                "slack": "https://zendframework-slack.herokuapp.com",
-                "forum": "https://discourse.zendframework.com/c/questions/expressive"
-            },
-            "time": "2018-03-06T20:55:46+00:00"
+            "time": "2018-03-06T22:42:26+00:00"
         },
         {
             "name": "zendframework/zend-http",
@@ -2852,17 +2819,10 @@
             "time": "2018-02-26T15:56:54+00:00"
         }
     ],
-    "aliases": [
-        {
-            "alias": "3.0.0rc2",
-            "alias_normalized": "3.0.0.0-RC2",
-            "version": "dev-head-options-requests",
-            "package": "zendframework/zend-expressive-router"
-        }
-    ],
+    "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {
-        "zendframework/zend-expressive-router": 20,
+        "zendframework/zend-expressive-router": 5,
         "zendframework/zend-stratigility": 5
     },
     "prefer-stable": false,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "55a8ef579fc029275345dd8bffd3a1ac",
+    "content-hash": "83aa8a8d660379373928b9c3f549627b",
     "packages": [
         {
             "name": "container-interop/container-interop",
@@ -390,16 +390,16 @@
         },
         {
             "name": "zendframework/zend-expressive-router",
-            "version": "3.0.0rc1",
+            "version": "dev-head-options-requests",
             "source": {
                 "type": "git",
-                "url": "https://github.com/zendframework/zend-expressive-router.git",
-                "reference": "a131ab7f555e5a75458cae870f7bb44381eac7fa"
+                "url": "https://github.com/webimpress/zend-expressive-router.git",
+                "reference": "c1e704096b37897410414246a09bd00e186e41c7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-expressive-router/zipball/a131ab7f555e5a75458cae870f7bb44381eac7fa",
-                "reference": "a131ab7f555e5a75458cae870f7bb44381eac7fa",
+                "url": "https://api.github.com/repos/webimpress/zend-expressive-router/zipball/c1e704096b37897410414246a09bd00e186e41c7",
+                "reference": "c1e704096b37897410414246a09bd00e186e41c7",
                 "shasum": ""
             },
             "require": {
@@ -413,7 +413,8 @@
                 "malukenho/docheader": "^0.1.6",
                 "phpunit/phpunit": "^6.5.5",
                 "zendframework/zend-coding-standard": "~1.0.0",
-                "zendframework/zend-diactoros": "^1.7"
+                "zendframework/zend-diactoros": "^1.7",
+                "zendframework/zend-stratigility": "^3.0.0rc1"
             },
             "suggest": {
                 "zendframework/zend-expressive-aurarouter": "^3.0 to use the Aura.Router routing adapter",
@@ -436,22 +437,55 @@
                     "Zend\\Expressive\\Router\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "ZendTest\\Expressive\\Router\\": "test/"
+                }
+            },
+            "scripts": {
+                "check": [
+                    "@license-check",
+                    "@cs-check",
+                    "@test"
+                ],
+                "cs-check": [
+                    "phpcs"
+                ],
+                "cs-fix": [
+                    "phpcbf"
+                ],
+                "test": [
+                    "phpunit --colors=always"
+                ],
+                "test-coverage": [
+                    "phpunit --colors=always --coverage-clover clover.xml"
+                ],
+                "license-check": [
+                    "docheader check src/ test/"
+                ]
+            },
             "license": [
                 "BSD-3-Clause"
             ],
             "description": "Router subcomponent for Expressive",
             "keywords": [
-                "ZendFramework",
                 "expressive",
                 "http",
                 "middleware",
                 "psr",
                 "psr-7",
                 "zend-expressive",
+                "zendframework",
                 "zf"
             ],
-            "time": "2018-03-05T14:14:24+00:00"
+            "support": {
+                "issues": "https://github.com/zendframework/zend-expressive-router/issues",
+                "source": "https://github.com/zendframework/zend-expressive-router",
+                "rss": "https://github.com/zendframework/zend-expressive-router/releases.atom",
+                "slack": "https://zendframework-slack.herokuapp.com",
+                "forum": "https://discourse.zendframework.com/c/questions/expressive"
+            },
+            "time": "2018-03-06T17:43:52+00:00"
         },
         {
             "name": "zendframework/zend-http",
@@ -2390,7 +2424,7 @@
         },
         {
             "name": "symfony/console",
-            "version": "v4.0.5",
+            "version": "v4.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
@@ -2458,16 +2492,16 @@
         },
         {
             "name": "symfony/finder",
-            "version": "v4.0.5",
+            "version": "v4.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "552e244df10237f845a94fd64b194f848805e34b"
+                "reference": "44a796d2ecc2a16a5fc8f2956a34ee617934d55f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/552e244df10237f845a94fd64b194f848805e34b",
-                "reference": "552e244df10237f845a94fd64b194f848805e34b",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/44a796d2ecc2a16a5fc8f2956a34ee617934d55f",
+                "reference": "44a796d2ecc2a16a5fc8f2956a34ee617934d55f",
                 "shasum": ""
             },
             "require": {
@@ -2503,7 +2537,7 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2018-02-11T17:17:44+00:00"
+            "time": "2018-03-05T18:28:26+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
@@ -2749,12 +2783,87 @@
                 "zf2"
             ],
             "time": "2017-05-17T17:00:12+00:00"
+        },
+        {
+            "name": "zendframework/zend-stratigility",
+            "version": "3.0.0rc1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/zend-stratigility.git",
+                "reference": "6e76a8bd5b50d1cbd0b7f702a6f61293290b4382"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-stratigility/zipball/6e76a8bd5b50d1cbd0b7f702a6f61293290b4382",
+                "reference": "6e76a8bd5b50d1cbd0b7f702a6f61293290b4382",
+                "shasum": ""
+            },
+            "require": {
+                "fig/http-message-util": "^1.1",
+                "php": "^7.1",
+                "psr/http-message": "^1.0",
+                "psr/http-server-middleware": "^1.0",
+                "zendframework/zend-escaper": "^2.3"
+            },
+            "conflict": {
+                "zendframework/zend-diactoros": "<1.7.1"
+            },
+            "require-dev": {
+                "malukenho/docheader": "^0.1.6",
+                "phpunit/phpunit": "^7.0.1",
+                "zendframework/zend-coding-standard": "~1.0.0",
+                "zendframework/zend-diactoros": "^1.7.1"
+            },
+            "suggest": {
+                "psr/http-message-implementation": "Please install a psr/http-message-implementation to consume Stratigility; e.g., zendframework/zend-diactoros"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev",
+                    "dev-develop": "3.1-dev",
+                    "dev-release-3.0.0": "3.0.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/functions/double-pass-middleware.php",
+                    "src/functions/host.php",
+                    "src/functions/middleware.php",
+                    "src/functions/path.php"
+                ],
+                "psr-4": {
+                    "Zend\\Stratigility\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "PSR-7 middleware foundation for building and dispatching middleware pipelines",
+            "keywords": [
+                "ZendFramework",
+                "http",
+                "middleware",
+                "psr-15",
+                "psr-7",
+                "zf"
+            ],
+            "time": "2018-02-26T15:56:54+00:00"
         }
     ],
-    "aliases": [],
+    "aliases": [
+        {
+            "alias": "3.0.0rc2",
+            "alias_normalized": "3.0.0.0-RC2",
+            "version": "dev-head-options-requests",
+            "package": "zendframework/zend-expressive-router"
+        }
+    ],
     "minimum-stability": "stable",
     "stability-flags": {
-        "zendframework/zend-expressive-router": 5
+        "zendframework/zend-expressive-router": 20,
+        "zendframework/zend-stratigility": 5
     },
     "prefer-stable": false,
     "prefer-lowest": false,

--- a/src/ZendRouter.php
+++ b/src/ZendRouter.php
@@ -96,11 +96,6 @@ class ZendRouter implements RouterInterface
 
         $zendRequest = Psr7ServerRequest::toZend($request, true);
         $match = $this->zendRouter->match($zendRequest);
-        if ($request->getMethod() === RequestMethod::METHOD_HEAD
-            && (null === $match || null !== $match->getParam(self::METHOD_NOT_ALLOWED_ROUTE))
-        ) {
-            $match = $this->zendRouter->match($zendRequest->setMethod(RequestMethod::METHOD_GET));
-        }
 
         if (null === $match) {
             // No route matched at all; to indicate that it's not due to the

--- a/test/ImplicitMethodsIntegrationTest.php
+++ b/test/ImplicitMethodsIntegrationTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace ZendTest\Expressive\Router;
 
+use Generator;
 use Zend\Expressive\Router\RouterInterface;
 use Zend\Expressive\Router\Test\ImplicitMethodsIntegrationTest as RouterIntegrationTest;
 use Zend\Expressive\Router\ZendRouter;
@@ -18,5 +19,20 @@ class ImplicitMethodsIntegrationTest extends RouterIntegrationTest
     public function getRouter() : RouterInterface
     {
         return new ZendRouter();
+    }
+
+    public function implicitRoutesAndRequests() : Generator
+    {
+        $options = [
+            'constraints' => [
+                'version' => '\d+',
+            ],
+        ];
+
+        // @codingStandardsIgnoreStart
+        //                  route                route options, request       params
+        yield 'static'  => ['/api/v1/me',        $options,      '/api/v1/me', []];
+        yield 'dynamic' => ['/api/v:version/me', $options,      '/api/v3/me', ['version' => '3']];
+        // @codingStandardsIgnoreEnd
     }
 }


### PR DESCRIPTION
Updates to use the latest (proposed) tests from zend-expressive-router for testing router capabilities surrounding implicit HEAD and OPTIONS requests, as well as correctly identifying allowed methods.

To pass the tests, one change was reverted from #37: we no longer check in the router for a HEAD request and re-check against GET.

~~This is a WIP; do not merge until zendframework/zend-expressive-router#58 is merged and tagged in a new release.~~