### PR TITLE
Updates to zend-expressive-router 3.0.0rc3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "php": "^7.1",
         "fig/http-message-util": "^1.1.2",
         "psr/http-message": "^1.0.1",
-        "zendframework/zend-expressive-router": "^3.0.0rc2",
+        "zendframework/zend-expressive-router": "^3.0.0rc3",
         "zendframework/zend-psr7bridge": "^0.2.2 || ^1.0.0",
         "zendframework/zend-router": "^3.0.2"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "a8b4634d72581ecace29210f9d18ca7c",
+    "content-hash": "d9490539e27655ebbf6a7de245b3b600",
     "packages": [
         {
             "name": "container-interop/container-interop",
@@ -390,16 +390,16 @@
         },
         {
             "name": "zendframework/zend-expressive-router",
-            "version": "3.0.0rc2",
+            "version": "3.0.0rc3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-expressive-router.git",
-                "reference": "97ea9940c72222586e832913529b097ddcc0b2e4"
+                "reference": "c4380e07a96fede84e8eabbe2698120fa3df7332"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-expressive-router/zipball/97ea9940c72222586e832913529b097ddcc0b2e4",
-                "reference": "97ea9940c72222586e832913529b097ddcc0b2e4",
+                "url": "https://api.github.com/repos/zendframework/zend-expressive-router/zipball/c4380e07a96fede84e8eabbe2698120fa3df7332",
+                "reference": "c4380e07a96fede84e8eabbe2698120fa3df7332",
                 "shasum": ""
             },
             "require": {
@@ -452,7 +452,7 @@
                 "zend-expressive",
                 "zf"
             ],
-            "time": "2018-03-06T22:42:26+00:00"
+            "time": "2018-03-07T15:38:28+00:00"
         },
         {
             "name": "zendframework/zend-http",

--- a/src/ZendRouter.php
+++ b/src/ZendRouter.php
@@ -29,14 +29,6 @@ use Zend\Router\RouteMatch;
  */
 class ZendRouter implements RouterInterface
 {
-    /**
-     * Implicitly supported HTTP methods on any route.
-     */
-    public const HTTP_METHODS_IMPLICIT = [
-        RequestMethod::METHOD_HEAD,
-        RequestMethod::METHOD_OPTIONS,
-    ];
-
     public const METHOD_NOT_ALLOWED_ROUTE = 'method_not_allowed';
 
     /**

--- a/test/ZendRouterTest.php
+++ b/test/ZendRouterTest.php
@@ -298,26 +298,6 @@ class ZendRouterTest extends TestCase
         $this->assertFalse($result->isMethodFailure());
     }
 
-    public function testMatchedRouteNameNoAllowedMethods()
-    {
-        $middleware = $this->getMiddleware();
-
-        $zendRouter = new ZendRouter();
-        $zendRouter->addRoute(new Route('/foo', $middleware, [], '/foo'));
-
-        $request = new ServerRequest(
-            ['REQUEST_METHOD' => RequestMethod::METHOD_HEAD],
-            [],
-            '/foo',
-            RequestMethod::METHOD_HEAD
-        );
-        $result = $zendRouter->match($request);
-        $this->assertInstanceOf(RouteResult::class, $result);
-        $this->assertFalse($result->isSuccess());
-        $this->assertFalse($result->getMatchedRoute());
-        $this->assertSame([], $result->getAllowedMethods());
-    }
-
     public function testMatchedRouteNameWhenGetMethodAllowed()
     {
         $middleware = $this->getMiddleware();


### PR DESCRIPTION
rc3 updates `Route` to no longer allow an empty list of HTTP methods via its constructor. This eliminates the need for one test in the suite.